### PR TITLE
changing '/' to '.' in url for 01_command_line.Rmd

### DIFF
--- a/01_command_line.Rmd
+++ b/01_command_line.Rmd
@@ -69,7 +69,7 @@ First, launch a web browser, the image below shows the Microsoft Edge browser:
 
 ![](`r git_url19` "New web browser window") 
 
-Next, navigate to the following Git download URL in your browser [https://git-scm/com/downloads](https://git-scm.com/downloads){rel="noopener noreferrer" target="_blank"}:
+Next, navigate to the following Git download URL in your browser [https://git-scm.com/downloads](https://git-scm.com/downloads){rel="noopener noreferrer" target="_blank"}:
 
 ![](`r git_url20` "git website") 
 


### PR DESCRIPTION
fixing a typo in the docs